### PR TITLE
fix(53figures): Uses sa4ss::add_figure

### DIFF
--- a/documents/write-up/53figures.Rmd
+++ b/documents/write-up/53figures.Rmd
@@ -4,358 +4,1310 @@
 ```
 # Figures
 
-![Map of management and the 2023 assessment area along with fleet spatial structure and survey ranges for `r spp` off the U.S. West Coast. \label{fig:map}](../figures/assessment_map.png){width="100%," height="100%," alt="Map of U.S. West Coast showing indicating coastwide management, assessment, and survey structure, and state-specific fleet structure"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/assessment_map.png",
+  caption = "Map of management and the 2023 assessment area along with fleet spatial structure and survey ranges for `r spp` off the U.S. West Coast",
+  alt_caption = "Map of U.S. West Coast showing indicating coastwide management, assessment, and survey structure, and state-specific fleet structure.",
+  label = "fig:map"
+)
+```
 
-![Total removals for `r spp` off the U.S. West Coast from 1892-2022 by fleet (TWL = trawl, NTWL = non-trawl, Rec = recreational, ASHOP = at-sea hake, FOR = foreign). \label{fig:catches}](../figures/catch2 landings stacked_custom.png){width="100%," height="100%," alt="Stacked bar plot showing total removals are mainly from trawl fleets, were high from 1940-2000, foreign fishing peaked in the 1970s, fishing was near zero from 2000-2015, and then increased modestly"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/catch2 landings stacked_custom.png",
+  caption = "Total removals for `r spp` off the U.S. West Coast from 1892-2022 by fleet (TWL = trawl, NTWL = non-trawl, Rec = recreational, ASHOP = at-sea hake, FOR = foreign)",
+  alt_caption = "Stacked bar plot showing total removals are mainly from trawl fleets, were high from 1940-2000, foreign fishing peaked in the 1970s, fishing was near zero from 2000-2015, and then increased modestly.",
+  label = "fig:catches"
+)
+```
 
-![Illustration of types of data used for each fleet within the assessment for `r spp` off the U.S. West Coast. \label{fig:data-plot}](../figures/data_plot_custom.png){width="100%," height="100%," alt="Horizontal bar plot showing data types available by year for each fleet. Commerical catches started in the early 1900s, and recreational in the 1920s for California and around 1970 for other states. Commercial and recreational composition data started in the 1970s and 1980s, with fewer years of age data compared to lengths. Fishery independent indices and composition data started in the 1980s"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/data_plot_custom.png",
+  caption = "Illustration of types of data used for each fleet within the assessment for `r spp` off the U.S. West Coast",
+  alt_caption = "Horizontal bar plot showing data types available by year for each fleet. Commerical catches started in the early 1900s, and recreational in the 1920s for California and around 1970 for other states. Commercial and recreational composition data started in the 1970s and 1980s, with fewer years of age data compared to lengths. Fishery independent indices and composition data started in the 1980s.",
+  label = "fig:data-plot"
+)
+```
 
-![Length composition data for the California trawl fishery for females (red), males (blue), and unsexed (black). \label{fig:CA_twl_lencomp}](../figures/plots/comp_lendat_bubflt1mkt0_page2.png){width="100%" height="100%" alt="Bubble plot of California trawl length compositions for males, females, and unsexed fish"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lendat_bubflt1mkt0_page2.png",
+  caption = "Length composition data for the California trawl fishery for females (red), males (blue), and unsexed (black)",
+  alt_caption = "Bubble plot of California trawl length compositions for males, females, and unsexed fish.",
+  label = "fig:CA_twl_lencomp"
+)
+```
 
-![Length composition data for the Oregon trawl fishery for females (red) and males (blue). \label{fig:OR_twl_lencomp}](../figures/plots/comp_lendat_bubflt2mkt0_page3.png){width="100%" height="100%" alt="Bubble plot of Oregon trawl length compositions for males and females"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lendat_bubflt2mkt0_page3.png",
+  caption = "Length composition data for the Oregon trawl fishery for females (red) and males (blue)",
+  alt_caption = "Bubble plot of Oregon trawl length compositions for males and females.",
+  label = "fig:OR_twl_lencomp"
+)
+```
 
-![Length composition data for the Washington trawl fishery for females (red), males (blue), and unsexed (black). \label{fig:WA_twl_lencomp}](../figures/plots/comp_lendat_bubflt3mkt0_page3.png){width="100%" height="100%" alt="Bubble plot of Washington trawl length compositions for males, females, and unsexed fish"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lendat_bubflt3mkt0_page3.png",
+  caption = "Length composition data for the Washington trawl fishery for females (red), males (blue), and unsexed (black)",
+  alt_caption = "Bubble plot of Washington trawl length compositions for males, females, and unsexed fish.",
+  label = "fig:WA_twl_lencomp"
+)
+```
 
-![Length composition data for the California non-trawl fishery for females (red), males (blue), and unsexed (black). \label{fig:CA_ntwl_lencomp}](../figures/plots/comp_lendat_bubflt4mkt0_page2.png){width="100%" height="100%" alt="Bubble plot of California non-trawl length compositions for males, females, and unsexed fish"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lendat_bubflt4mkt0_page2.png",
+  caption = "Length composition data for the California non-trawl fishery for females (red), males (blue), and unsexed (black)",
+  alt_caption = "Bubble plot of California non-trawl length compositions for males, females, and unsexed fish.",
+  label = "fig:CA_ntwl_lencomp"
+)
+```
 
-![Length composition data for the Oregon non-trawl fishery for females (red) and males (blue). \label{fig:OR_ntwl_lencomp}](../figures/plots/comp_lendat_bubflt5mkt0.png){width="100%" height="100%" alt="Bubble plot of Oregon non-trawl length compositions for males and females"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lendat_bubflt5mkt0.png",
+  caption = "Length composition data for the Oregon non-trawl fishery for females (red) and males (blue)",
+  alt_caption = "Bubble plot of Oregon non-trawl length compositions for males and females.",
+  label = "fig:OR_ntwl_lencomp"
+)
+```
  
-![Length composition data for the Washington non-trawl fishery for females (red) and males (blue). \label{fig:WA_ntwl_lencomp}](../figures/plots/comp_lendat_bubflt6mkt0.png){width="100%" height="100%" alt="Bubble plot of Washington non-trawl length compositions for males and females"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lendat_bubflt6mkt0.png",
+  caption = "Length composition data for the Washington non-trawl fishery for females (red) and males (blue)",
+  alt_caption = "Bubble plot of Washington non-trawl length compositions for males and females.",
+  label = "fig:WA_ntwl_lencomp"
+)
+```
 
-![Age composition data for the California trawl fishery for females (red) and males (blue). \label{fig:CA_twl_agecomp}](../figures/plots/comp_agedat_bubflt1mkt0_page2.png){width="100%" height="100%" alt="Bubble plot of California trawl age compositions for males and females"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agedat_bubflt1mkt0_page2.png",
+  caption = "Age composition data for the California trawl fishery for females (red) and males (blue)",
+  alt_caption = "Bubble plot of California trawl age compositions for males and females.",
+  label = "fig:CA_twl_agecomp"
+)
+```
 
-![Age composition data for the Oregon trawl fishery for females (red) and males (blue). \label{fig:OR_twl_agecomp}](../figures/plots/comp_agedat_bubflt2mkt0_page2.png){width="100%" height="100%" alt="Bubble plot of Oregon trawl age compositions for males and females"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agedat_bubflt2mkt0_page2.png",
+  caption = "Age composition data for the Oregon trawl fishery for females (red) and males (blue)",
+  alt_caption = "Bubble plot of Oregon trawl age compositions for males and females.",
+  label = "fig:OR_twl_agecomp"
+)
+```
 
-![Age composition data for the Washington trawl fishery for females (red) and males (blue). \label{fig:WA_twl_agecomp}](../figures/plots/comp_agedat_bubflt3mkt0_page3.png){width="100%" height="100%" alt="Bubble plot of Washington trawl age compositions for males and females"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agedat_bubflt3mkt0_page3.png",
+  caption = "Age composition data for the Washington trawl fishery for females (red) and males (blue)",
+  alt_caption = "Bubble plot of Washington trawl age compositions for males and females.",
+  label = "fig:WA_twl_agecomp"
+)
+```
 
-![Age composition data for the California non-trawl fishery for females (red) and males (blue). \label{fig:CA_ntwl_agecomp}](../figures/plots/comp_agedat_bubflt4mkt0.png){width="100%" height="100%" alt="Bubble plot of California non-trawl age compositions for males and females"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agedat_bubflt4mkt0.png",
+  caption = "Age composition data for the California non-trawl fishery for females (red) and males (blue)",
+  alt_caption = "Bubble plot of California non-trawl age compositions for males and females.",
+  label = "fig:CA_ntwl_agecomp"
+)
+```
 
-![Age composition data for the Oregon non-trawl fishery for females (red) and males (blue). \label{fig:OR_ntwl_agecomp}](../figures/plots/comp_agedat_bubflt5mkt0.png){width="100%" height="100%" alt="Bubble plot of Oregon non-trawl age compositions for males and females"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agedat_bubflt5mkt0.png",
+  caption = "Age composition data for the Oregon non-trawl fishery for females (red) and males (blue)",
+  alt_caption = "Bubble plot of Oregon non-trawl age compositions for males and females.",
+  label = "fig:OR_ntwl_agecomp"
+)
+```
 
-![Age composition data for the Washington non-trawl fishery for females (red) and males (blue). \label{fig:WA_ntwl_agecomp}](../figures/plots/comp_agedat_bubflt6mkt0.png){width="100%" height="100%" alt="Bubble plot of Washington non-trawl age compositions for males and females"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agedat_bubflt6mkt0.png",
+  caption = "Age composition data for the Washington non-trawl fishery for females (red) and males (blue)",
+  alt_caption = "Bubble plot of Washington non-trawl age compositions for males and females.",
+  label = "fig:WA_ntwl_agecomp"
+)
+```
 
-![Length composition data for the Oregon at-sea hake fishery for females (red) and males (blue). \label{fig:OR_hake_lencomp}](../figures/plots/comp_lendat_bubflt11mkt0.png){width="100%" height="100%" alt="Bubble plot of Oregon at-sea hake length compositions for males and females"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lendat_bubflt11mkt0.png",
+  caption = "Length composition data for the Oregon at-sea hake fishery for females (red) and males (blue)",
+  alt_caption = "Bubble plot of Oregon at-sea hake length compositions for males and females.",
+  label = "fig:OR_hake_lencomp"
+)
+```
 
-![Length composition data for the Washington at-sea hake fishery for females (red) and males (blue). \label{fig:WA_hake_lencomp}](../figures/plots/comp_lendat_bubflt12mkt0.png){width="100%" height="100%" alt="Bubble plot of Washington at-sea hake length compositions for males and females"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lendat_bubflt12mkt0.png",
+  caption = "Length composition data for the Washington at-sea hake fishery for females (red) and males (blue)",
+  alt_caption = "Bubble plot of Washington at-sea hake length compositions for males and females.",
+  label = "fig:WA_hake_lencomp"
+)
+```
 
-![Age composition data for the Oregon at-sea hake fishery for females (red) and males (blue). \label{fig:OR_hake_agecomp}](../figures/plots/comp_agedat_bubflt11mkt0.png){width="100%" height="100%" alt="Bubble plot of Oregon at-sea hake age compositions for males and females"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agedat_bubflt11mkt0.png",
+  caption = "Age composition data for the Oregon at-sea hake fishery for females (red) and males (blue)",
+  alt_caption = "Bubble plot of Oregon at-sea hake age compositions for males and females.",
+  label = "fig:OR_hake_agecomp"
+)
+```
 
-![Age composition data for the Washington at-sea hake fishery for females (red) and males (blue). \label{fig:WA_hake_agecomp}](../figures/plots/comp_agedat_bubflt12mkt0.png){width="100%" height="100%" alt="Bubble plot of Washington at-sea hake age compositions for males and females"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agedat_bubflt12mkt0.png",
+  caption = "Age composition data for the Washington at-sea hake fishery for females (red) and males (blue)",
+  alt_caption = "Bubble plot of Washington at-sea hake age compositions for males and females.",
+  label = "fig:WA_hake_agecomp"
+)
+```
 
-![Length composition data for the California recreational fishery for unsexed (black). \label{fig:CA_rec_lencomp}](../figures/plots/comp_lendat_bubflt7mkt0_page2.png){width="100%" height="100%" alt="Bubble plot of California recreational length compositions for unsexed fish"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lendat_bubflt7mkt0_page2.png",
+  caption = "Length composition data for the California recreational fishery for unsexed (black)",
+  alt_caption = "Bubble plot of California recreational length compositions for unsexed fish.",
+  label = "fig:CA_rec_lencomp"
+)
+```
 
-![Length composition data for the Oregon recreational fishery for females (red), males (blue), and unsexed (black). \label{fig:OR_rec_lencomp}](../figures/plots/comp_lendat_bubflt8mkt0_page2.png){width="100%" height="100%" alt="Bubble plot of Oregon recreational length compositions for males, females, and unsexed fish"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lendat_bubflt8mkt0_page2.png",
+  caption = "Length composition data for the Oregon recreational fishery for females (red), males (blue), and unsexed (black)",
+  alt_caption = "Bubble plot of Oregon recreational length compositions for males, females, and unsexed fish.",
+  label = "fig:OR_rec_lencomp"
+)
+```
 
-![Length composition data for the Washington recreational fishery for females (red), males (blue), and unsexed (black). \label{fig:WA_rec_lencomp}](../figures/plots/comp_lendat_bubflt9mkt0_page2.png){width="100%" height="100%" alt="Bubble plot of Washington non-trawl length compositions for males, females, and unsexed fish"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lendat_bubflt9mkt0_page2.png",
+  caption = "Length composition data for the Washington recreational fishery for females (red), males (blue), and unsexed (black)",
+  alt_caption = "Bubble plot of Washington non-trawl length compositions for males, females, and unsexed fish.",
+  label = "fig:WA_rec_lencomp"
+)
+```
 
-![Aggregate length composition data for the three fisheries with bimodal patterns in length. \label{fig:agglencomp}](../figures/comp_lendat__aggregated_across_time_custom.png){width="100%" height="100%" alt="Aggregate plots of length compositions for males, females, and unsexed fish across all length distributions"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/comp_lendat__aggregated_across_time_custom.png",
+  caption = "Aggregate length composition data for the three fisheries with bimodal patterns in length",
+  alt_caption = "Aggregate plots of length compositions for males, females, and unsexed fish across all length distributions.",
+  label = "fig:agglencomp"
+)
+```
 
-![Age composition data for the Oregon recreational fishery for females (red) and males (blue). \label{fig:OR_rec_agecomp}](../figures/plots/comp_agedat_bubflt8mkt0.png){width="100%" height="100%" alt="Bubble plot of Oregon recreational age compositions for males and females"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agedat_bubflt8mkt0.png",
+  caption = "Age composition data for the Oregon recreational fishery for females (red) and males (blue)",
+  alt_caption = "Bubble plot of Oregon recreational age compositions for males and females.",
+  label = "fig:OR_rec_agecomp"
+)
+```
 
-![Age composition data for the Washington recreational fishery for females (red) and males (blue). \label{fig:WA_rec_agecomp}](../figures/plots/comp_agedat_bubflt9mkt0.png){width="100%" height="100%" alt="Bubble plot of Washington recreational age compositions for males and females"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agedat_bubflt9mkt0.png",
+  caption = "Age composition data for the Washington recreational fishery for females (red) and males (blue)",
+  alt_caption = "Bubble plot of Washington recreational age compositions for males and females.",
+  label = "fig:WA_rec_agecomp"
+)
+```
 
-![Map of \gls{s-wcgbt} stations and density of catches of `r spp`. Faint gray dots are tows without `r spp`. Larger redder circles indicate higher catch rates. \label{fig:wcgbts-tows}](../figures/cpue_map.png){width="100%" height="100%" alt="Map of survey tows of canary rockfish showing highest catch rates in northern Oregon and especially Washington, with catches tapering off south of San Francisco Bay and virtually no catches south of Point Conception"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/cpue_map.png",
+  caption = "Map of \gls{s-wcgbt} stations and density of catches of `r spp`. Faint gray dots are tows without `r spp`. Larger redder circles indicate higher catch rates",
+  alt_caption = "Map of survey tows of canary rockfish showing highest catch rates in northern Oregon and especially Washington, with catches tapering off south of San Francisco Bay and virtually no catches south of Point Conception.",
+  label = "fig:wcgbts-tows"
+)
+```
 
-![Length composition data for the \gls{s-wcgbt} for females (red) and males (blue). \label{fig:wcgbts_lencomp}](../figures/plots/comp_lendat_bubflt28mkt0.png){width="100%" height="100%" alt="Bubble plot of WCGBTS length compositions for males and females showing a wide range of lengths over time"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lendat_bubflt28mkt0.png",
+  caption = "Length composition data for the \gls{s-wcgbt} for females (red) and males (blue)",
+  alt_caption = "Bubble plot of WCGBTS length compositions for males and females showing a wide range of lengths over time.",
+  label = "fig:wcgbts_lencomp"
+)
+```
 
-![Length composition data for the early years of the Triennial Survey for females (red) and males (blue). \label{fig:triearly_lencomp}](../figures/plots/comp_lendat_bubflt29mkt0.png){width="100%" height="100%" alt="Bubble plot of the Triennial survey length compositions for males and females from 1980 to 1992"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lendat_bubflt29mkt0.png",
+  caption = "Length composition data for the early years of the Triennial Survey for females (red) and males (blue)",
+  alt_caption = "Bubble plot of the Triennial survey length compositions for males and females from 1980 to 1992.",
+  label = "fig:triearly_lencomp"
+)
+```
 
-![Length composition data for the later years of the Triennial Survey for females (red) and males (blue). \label{fig:trilate_lencomp}](../figures/plots/comp_lendat_bubflt30mkt0.png){width="100%" height="100%" alt="Bubble plot of the Triennial survey length compositions for males and females from 1995 to 2004"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lendat_bubflt30mkt0.png",
+  caption = "Length composition data for the later years of the Triennial Survey for females (red) and males (blue)",
+  alt_caption = "Bubble plot of the Triennial survey length compositions for males and females from 1995 to 2004.",
+  label = "fig:trilate_lencomp"
+)
+```
 
 ## Biology
 
-![Maturity at age relationship used for the current assessment (black), compared to the last benchmark assessment (red). Sample sizes are shown as gray circles. \label{fig:compare_maturity}](../figures/compare_maturity.png){width="100%" height="100%" alt="Two logistic curves for 2015 and 2023, 2015 is shifted left of 2023 and asymptotes below 1, 2023 asymptotes at 1"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/compare_maturity.png",
+  caption = "Maturity at age relationship used for the current assessment (black), compared to the last benchmark assessment (red). Sample sizes are shown as gray circles",
+  alt_caption = "Two logistic curves for 2015 and 2023, 2015 is shifted left of 2023 and asymptotes below 1, 2023 asymptotes at 1.",
+  label = "fig:compare_maturity"
+)
+```
 
-![Fecundity at length relationship. \label{fig:compare_fecundity}](../figures/compare_fecundity.png){width="100%," height="100%," alt="Two exponential curves for 2015 and 2023, 2023 is lower"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/compare_fecundity.png",
+  caption = "Fecundity at length relationship",
+  alt_caption = "Two exponential curves for 2015 and 2023, 2023 is lower.",
+  label = "fig:compare_fecundity"
+)
+```
 
-![Weight-length relationship for male and females. \label{fig:WL}](../figures/WL.png){width="100%," height="100%," alt="Exponential weight-length curves for males and females nearly overlapping, with relatively small spread of data"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/WL.png",
+  caption = "Weight-length relationship for male and females",
+  alt_caption = "Exponential weight-length curves for males and females nearly overlapping, with relatively small spread of data.",
+  label = "fig:WL"
+)
+```
 
-![Weight-length comparisons for males and females with previous benchmark assessment. \label{fig:compare_WL}](../figures/compare_WL.png){width="100%," height="100%," alt="2015 and 2023 exponential weight-length relationships nearly overlapping and for sexes"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/compare_WL.png",
+  caption = "Weight-length comparisons for males and females with previous benchmark assessment",
+  alt_caption = "2015 and 2023 exponential weight-length relationships nearly overlapping and for sexes.",
+  label = "fig:compare_WL"
+)
+```
 
-![Externally estimated age-length relationship by Sex and latitude, where "North" is latitudes greater than $43.3672^\circ$N (Coos Bay, OR) for females (red), males (blue), and unsexed (yellow). Note that in the base model growth is estimated internally and is assumed constant across latitudes. \label{fig:spatial_AL}](../figures/growth_diffs.png){width="100%," height="100%," alt="Figure showing age-length data and four fitted curves for north and south males and females. Females are larger than males, but northern individuals are only slightly larger than southern individuals"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/growth_diffs.png",
+  caption = "Externally estimated age-length relationship by Sex and latitude, where "North" is latitudes greater than $43.3672^\circ$N (Coos Bay, OR) for females (red), males (blue), and unsexed (yellow). Note that in the base model growth is estimated internally and is assumed constant across latitudes",
+  alt_caption = "Figure showing age-length data and four fitted curves for north and south males and females. Females are larger than males, but northern individuals are only slightly larger than southern individuals.",
+  label = "fig:spatial_AL"
+)
+```
 
-![Sex ratio by age in the \gls{s-wcgbt} for females (red), males (blue) and unsexed (green). \label{fig:sex_ratio_age}](../figures/age_fraction_female.png){width="100%," alt="Figure showing fraction female close to 50% until around age 20 when it becomes almost all male"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/age_fraction_female.png",
+  caption = "Sex ratio by age in the \gls{s-wcgbt} for females (red), males (blue) and unsexed (green)",
+  alt_caption = "Figure showing fraction female close to 50 percent until around age 20 when it becomes almost all male.",
+  label = "fig:sex_ratio_age"
+)
+```
 
-![Sex ratio by length in the \gls{s-wcgbt} for females (red), males (blue) and unsexed (green). \label{fig:sex_ratio_length}](../figures/length_fraction_female.png){width="100%," alt="Figure showing fraction female close to 50% until around 45 when it becomes almost all female"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/length_fraction_female.png",
+  caption = "Sex ratio by length in the \gls{s-wcgbt} for females (red), males (blue) and unsexed (green)",
+  alt_caption = "Figure showing fraction female close to 50 percent until around 45 when it becomes almost all female.",
+  label = "fig:sex_ratio_length"
+)
+```
 
 ## Model bridging
 
-![Model version bridge comparison of estimated spawning output of the 2015 assessment. \label{fig:bridge-exe-bio}](../figures/bridge0_exe_spawnbio_uncertainty.png){width="100%," alt="Figure showing spawning output from 2015 benchmark is similar when using the 2015 and 2023 versions of stock synthesis"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/bridge0_exe_spawnbio_uncertainty.png",
+  caption = "Model version bridge comparison of estimated spawning output of the 2015 assessment",
+  alt_caption = "Figure showing spawning output from 2015 benchmark is similar when using the 2015 and 2023 versions of stock synthesis.",
+  label = "fig:bridge-exe-bio"
+)
+```
 
-![Model version bridge comparison of estimated spawning output relative to unfished of the 2015 assessment. \label{fig:bridge-exe-relbio}](../figures/bridg0_exe_compare4_Bratio_uncertainty.png){width="100%," alt="Figure showing spawning output relative to unfished from 2015 benchmark is similar when using the 2015 and 2023 versions of stock synthesis"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/bridg0_exe_compare4_Bratio_uncertainty.png",
+  caption = "Model version bridge comparison of estimated spawning output relative to unfished of the 2015 assessment",
+  alt_caption = "Figure showing spawning output relative to unfished from 2015 benchmark is similar when using the 2015 and 2023 versions of stock synthesis.",
+  label = "fig:bridge-exe-relbio"
+)
+```
 
-![Data bridge comparison of estimated spawning output. Each step is done individually from the updated 2015 model except the final one (All data), which combines across steps. \label{fig:bridge-data-bio}](../figures/bridge1_data_spawnbio_uncertainty.png){width="100%," alt="Figure showing changes from the 2015 benchmark assessment as data are updated. Updating fishery data continue the increase in recovery while updating survey data result in recent declines"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/bridge1_data_spawnbio_uncertainty.png",
+  caption = "Data bridge comparison of estimated spawning output. Each step is done individually from the updated 2015 model except the final one (All data), which combines across steps",
+  alt_caption = "Figure showing changes from the 2015 benchmark assessment as data are updated. Updating fishery data continue the increase in recovery while updating survey data result in recent declines.",
+  label = "fig:bridge-data-bio"
+)
+```
 
-![Data bridge comparison of estimated spawning output relative to unfished. Each step is done individually from the updated 2015 model except the final one (All data), which combines across steps. \label{fig:bridge-data-relbio}](../figures/bridge1_data_compare4_Bratio_uncertainty.png){width="100%," alt="Figure showing patterns in spawning output relative to unfished are similar to spawning output as data are updated from 2015 benchmark"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/bridge1_data_compare4_Bratio_uncertainty.png",
+  caption = "Data bridge comparison of estimated spawning output relative to unfished. Each step is done individually from the updated 2015 model except the final one (All data), which combines across steps",
+  alt_caption = "Figure showing patterns in spawning output relative to unfished are similar to spawning output as data are updated from 2015 benchmark.",
+  label = "fig:bridge-data-relbio"
+)
+```
 
-![Life history parameters bridge comparison of estimated spawning output. Each step is done individually from the 'All data updated' model except the final one (All biology and data), which combines across steps. \label{fig:bridge-bio-bio}](../figures/bridge2_bio_spawnbio_uncertainty.png){width="100%," alt="Figure showing scale of spawning output changes from the 2015 benchmark as biological parameters are updated"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/bridge2_bio_spawnbio_uncertainty.png",
+  caption = "Life history parameters bridge comparison of estimated spawning output. Each step is done individually from the 'All data updated' model except the final one (All biology and data), which combines across steps",
+  alt_caption = "Figure showing scale of spawning output changes from the 2015 benchmark as biological parameters are updated.",
+  label = "fig:bridge-bio-bio"
+)
+```
 
-![Life history parameters bridge comparison of estimated spawning output relative to unfished. Each step is done individually from the 'All data updated' model except the final one (All biology and data), which combines across steps. \label{fig:bridge-bio-relbio}](../figures/bridge2_bio_compare4_Bratio_uncertainty.png){width="100%," alt="Figure showing spawning output relative to unfished are generally similar to the 2015 benchmark as biological parameters are updated"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/bridge2_bio_compare4_Bratio_uncertainty.png",
+  caption = "Life history parameters bridge comparison of estimated spawning output relative to unfished. Each step is done individually from the 'All data updated' model except the final one (All biology and data), which combines across steps",
+  alt_caption = "Figure showing spawning output relative to unfished are generally similar to the 2015 benchmark as biological parameters are updated.",
+  label = "fig:bridge-bio-relbio"
+)
+```
 
-![Bridge comparison of estimated spawning output when updating the structure of natural mortality. Each step is done cumulatively from the previous model. \label{fig:bridge-Mcons-bio}](../figures/bridge3_M_spawnbio_uncertainty.png){width="100%," alt="Figure showing greater spawning output compared to 2015 benchmark when natural mortality is age-invariant"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/bridge3_M_spawnbio_uncertainty.png",
+  caption = "Bridge comparison of estimated spawning output when updating the structure of natural mortality. Each step is done cumulatively from the previous model",
+  alt_caption = "Figure showing greater spawning output compared to 2015 benchmark when natural mortality is age-invariant.",
+  label = "fig:bridge-Mcons-bio"
+)
+```
 
-![Bridge comparison of estimated spawning output relative to unfished when updating the structure of natural mortality. Each step is done cumulatively from the previous model. \label{fig:bridge-Mcons-relbio}](../figures/bridge3_M_compare4_Bratio_uncertainty.png){width="100%," alt="Figure showing spawning output relative to unfished declines when natural mortality is age-invariant compared to the 2015 benchmark"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/bridge3_M_compare4_Bratio_uncertainty.png",
+  caption = "Bridge comparison of estimated spawning output relative to unfished when updating the structure of natural mortality. Each step is done cumulatively from the previous model",
+  alt_caption = "Figure showing spawning output relative to unfished declines when natural mortality is age-invariant compared to the 2015 benchmark.",
+  label = "fig:bridge-Mcons-relbio"
+)
+```
 
-![Spatial population structure and data reweighting bridge comparisons of estimated spawning output. \label{fig:bridge-spatial-bio}](../figures/bridge4_spatialAndTuning_spawnbio_uncertainty.png){width="100%," alt="Figure showing that changing the spatial population structure has little effect on spawning output but that applying current best practices for data weighting result in a greater decline in spawning output compared to the 2015 bechmark"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/bridge4_spatialAndTuning_spawnbio_uncertainty.png",
+  caption = "Spatial population structure and data reweighting bridge comparisons of estimated spawning output",
+  alt_caption = "Figure showing that changing the spatial population structure has little effect on spawning output but that applying current best practices for data weighting result in a greater decline in spawning output compared to the 2015 bechmark.",
+  label = "fig:bridge-spatial-bio"
+)
+```
 
-![Spatial population structure and data reweighting bridge comparisons of estimated spawning output relative to unfished. \label{fig:bridge-spatial-relbio}](../figures/bridge4_spatialAndTuning_compare4_Bratio_uncertainty.png){width="100%," alt="Figure showing that changing the spatial population structure has little effect on spawning output relative to unfished but that applying current best practices for data weighting result in a greater decline compared to the 2015 bechmark"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/bridge4_spatialAndTuning_compare4_Bratio_uncertainty.png",
+  caption = "Spatial population structure and data reweighting bridge comparisons of estimated spawning output relative to unfished",
+  alt_caption = "Figure showing that changing the spatial population structure has little effect on spawning output relative to unfished but that applying current best practices for data weighting result in a greater decline compared to the 2015 bechmark.",
+  label = "fig:bridge-spatial-relbio"
+)
+```
 
-![Selectivity bridge comparisons of estimated spawning output. Each step after the 'Coastwide model' is done cumulatively from the previous model. \label{fig:bridge-selex-bio}](../figures/bridge5_selex_spawnbio_uncertainty.png){width="100%," alt="Figure showing that allowing sex-dpendent selectivity decreases initial and increases recent spawning output"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/bridge5_selex_spawnbio_uncertainty.png",
+  caption = "Selectivity bridge comparisons of estimated spawning output. Each step after the 'Coastwide model' is done cumulatively from the previous model",
+  alt_caption = "Figure showing that allowing sex-dpendent selectivity decreases initial and increases recent spawning output.",
+  label = "fig:bridge-selex-bio"
+)
+```
 
-![Selectivity bridge comparisons of estimated spawning output relative to unfished. Each step after the 'Coastwide model' is done cumulatively from the previous model. \label{fig:bridge-selex-relbio}](../figures/bridge5_selex_compare4_Bratio_uncertainty.png){width="100%," alt="Figure showing that allowing sex-dpendent selectivity increases recent spawning output relative to unfished"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/bridge5_selex_compare4_Bratio_uncertainty.png",
+  caption = "Selectivity bridge comparisons of estimated spawning output relative to unfished. Each step after the 'Coastwide model' is done cumulatively from the previous model",
+  alt_caption = "Figure showing that allowing sex-dpendent selectivity increases recent spawning output relative to unfished.",
+  label = "fig:bridge-selex-relbio"
+)
+```
 
 ## Model results
 
 ### Estimated growth
 
-![Model estimated length-at-age in the beginning of the year. Shaded area indicates 95 percent distribution of length-at-age around the estimated growth curve. \label{fig:mod-est-len-age}](../figures/plots/bio1_sizeatage.png){width="100%," alt="Figure showing length at age relationship for males and females with females reaching a greater maximium size at age than males"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/bio1_sizeatage.png",
+  caption = "Model estimated length-at-age in the beginning of the year. Shaded area indicates 95 percent distribution of length-at-age around the estimated growth curve",
+  alt_caption = "Figure showing length at age relationship for males and females with females reaching a greater maximium size at age than males.",
+  label = "fig:mod-est-len-age"
+)
+```
 
 ### Selectivity
 
-```{r, results = 'asis'}
+```{r, results = "asis"}
 sa4ss::add_figure(
 filein = file.path(model_dir, "selectivity_comm.png"), 
 caption = "Selectivity curves for commercial fleets over time for females. If only one curve is included for a fleet it is applied over all years",
-alt_caption = "Figure showing logistic curves of length-based selectivty that tend to be shifted towards larger fish in the earlier time periods",
+alt_caption = "Figure showing logistic curves of length-based selectivty that tend to be shifted towards larger fish in the earlier time periods.",
 label = 'comm-selex-female')
 ```
 
-```{r, results = 'asis'}
+```{r, results = "asis"}
 sa4ss::add_figure(
 filein = file.path(model_dir, "selectivity_comm_males.png"), 
 caption = "Selectivity curves for commercial fleets over time for males. If only one curve is included for a fleet it is applied over all years",
-alt_caption = "Figure showing logistic curves of length-based selectivty that tend to be shifted towards larger fish in the earlier time periods and show a steep truncation at larger sizes",
+alt_caption = "Figure showing logistic curves of length-based selectivty that tend to be shifted towards larger fish in the earlier time periods and show a steep truncation at larger sizes.",
 label = 'comm-selex-male')
 ```
 
-```{r, results = 'asis'}
+```{r, results = "asis"}
 sa4ss::add_figure(
 filein = file.path(model_dir, "selectivity_noncomm.png"), 
 caption = "Selectivity curves for recreational and survey fleets over time for females. If only one curve is included for a fleet it is applied over all years",
-alt_caption = "Figure showing logistic curves of length-based selectivty that tend to be shifted towards smaller fish in the earlier time periods for recreational fleets. Survey curves are not time varying",
+alt_caption = "Figure showing logistic curves of length-based selectivty that tend to be shifted towards smaller fish in the earlier time periods for recreational fleets. Survey curves are not time varying.",
 label = 'noncomm-selex-female')
 ```
 
-```{r, results = 'asis'}
+```{r, results = "asis"}
 sa4ss::add_figure(
 filein = file.path(model_dir, "selectivity_noncomm_males.png"), 
 caption = "Selectivity curves for recreational and survey fleets over time for males. If only one curve is included for a fleet it is applied over all years",
-alt_caption = "Figure showing logistic curves of length-based selectivty that tend to be shifted towards smaller fish in the earlier time periods for recreational fleets. Survey curves are not time varying. All curves show a steep truncation at larger sizes",
+alt_caption = "Figure showing logistic curves of length-based selectivty that tend to be shifted towards smaller fish in the earlier time periods for recreational fleets. Survey curves are not time varying. All curves show a steep truncation at larger sizes.",
 label = 'noncomm-selex-male')
 ```
 
-<!-- ```{r, results = 'asis'} -->
-<!-- sa4ss::add_figure( -->
-<!-- filein = file.path(dir, "models", paste0(model_name), "UnavailableSpawningOutput.png"),  -->
-<!-- caption = "Proportion of spawning output unavailable due to selectivity for small and large fish. Panels are the amount (a: top left) and proportion (b: top right) of spawning output that is unavailable; c) mean age over time (bottom left); and d) mean selectivity of all fleets over time (bottom right)", -->
-<!-- alt_caption = "Four panel figure showing high proportion of unavailable biomass before 1940s, a lower proportion from 1940 to 2000, and an increasing proportin since 2000", -->
-<!-- label = 'unavail-bio') -->
-<!-- ``` -->
+<!-- ```{r, results = 'asis'}
+sa4ss::add_figure(
+filein = file.path(dir, "models", paste0(model_name), "UnavailableSpawningOutput.png"), 
+caption = "Proportion of spawning output unavailable due to selectivity for small and large fish. Panels are the amount (a: top left) and proportion (b: top right) of spawning output that is unavailable; c) mean age over time (bottom left); and d) mean selectivity of all fleets over time (bottom right)",
+alt_caption = "Four panel figure showing high proportion of unavailable biomass before 1940s, a lower proportion from 1940 to 2000, and an increasing proportin since 2000.",
+label = "unavail-bio")
+``` -->
 
 ### Recruitment
 
-![Estimated time series of age-0 recruits (1000s). \label{fig:recruits}](../figures/plots/ts11_Age-0_recruits_(1000s)_with_95_asymptotic_intervals.png){width="100%," alt="Figure recruits with estimated variability peaking in the 1960s, declining through the 1990s, and staying not trending until increasing in recent years"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/ts11_Age-0_recruits_(1000s)_with_95_asymptotic_intervals.png",
+  caption = "Estimated time series of age-0 recruits (1000s)",
+  alt_caption = "Figure recruits with estimated variability peaking in the 1960s, declining through the 1990s, and staying not trending until increasing in recent years.",
+  label = "fig:recruits"
+)
+```
 
-![Estimated time series of recruitment deviations (circles) and 95% confidence intervals (whiskers) for the main recruitment deviations (black) and early or forecast deviations (blue). \label{fig:rec-devs}](../figures/plots/recdevs2_withbars.png){width="100%," alt="Figure recruits with estimated variability peaking in the 1960s, declining through the 1990s, and staying not trending until increasing in recent years"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/recdevs2_withbars.png",
+  caption = "Estimated time series of recruitment deviations (circles) and 95 percent confidence intervals (whiskers) for the main recruitment deviations (black) and early or forecast deviations (blue)",
+  alt_caption = "Figure recruits with estimated variability peaking in the 1960s, declining through the 1990s, and staying not trending until increasing in recent years.",
+  label = "fig:rec-devs"
+)
+```
 
-![Stock-recruit curve with labels on first, last, and years with log-deviations greater than 0.50. Point colors indicate year, with warmer colors indicating earlier years and cooler colors in showing later years. \label{fig:bh-curve}](../figures/plots/SR_curve2.png){width="100%," alt="Figure showing lowering of spawning output with recruits in early years generally falling above the curve and recruits in recent years falling below the time series"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/SR_curve2.png",
+  caption = "Stock-recruit curve with labels on first, last, and years with log-deviations greater than 0.50. Point colors indicate year, with warmer colors indicating earlier years and cooler colors in showing later years",
+  alt_caption = "Figure showing lowering of spawning output with recruits in early years generally falling above the curve and recruits in recent years falling below the time series.",
+  label = "fig:bh-curve"
+)
+```
 
-![Points are transformed variances. Red line shows current settings for bias adjustment specified in control file. Blue line shows least squares estimate of alternative bias adjustment relationship for recruitment deviations. \label{fig:bias-adjust}](../figures/plots/recruit_fit_bias_adjust.png){width="100%," alt="Figure showing lowering of spawning output with recruits in early years generally falling above the curve and recruits in recent years falling below the time series"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/recruit_fit_bias_adjust.png",
+  caption = "Points are transformed variances. Red line shows current settings for bias adjustment specified in control file. Blue line shows least squares estimate of alternative bias adjustment relationship for recruitment deviations",
+  alt_caption = "Figure showing lowering of spawning output with recruits in early years generally falling above the curve and recruits in recent years falling below the time series.",
+  label = "fig:bias-adjust"
+)
+```
 
 ### Fits to data
 
 <!-- #### Length compositions -->
 
-![Length composition aggregated across years by fleet with the model estimated fit to the data by sex (green unsexed, red female, and blue male). \label{fig:len-agg-fit}](../figures/plots/comp_lenfit__aggregated_across_time.png){width="100%," alt="Figure showing fits of modeled length composition for all fleets generally matching the distribution observed in the data"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit__aggregated_across_time.png",
+  caption = "Length composition aggregated across years by fleet with the model estimated fit to the data by sex (green unsexed, red female, and blue male)",
+  alt_caption = "Figure showing fits of modeled length composition for all fleets generally matching the distribution observed in the data.",
+  label = "fig:len-agg-fit"
+)
+```
 
-![Pearson residuals for lengths in the California trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red), males (blue), and unsexed (black). \label{fig:len-pearson1}](../figures/plots/comp_lenfit_residsflt1mkt0_page2.png){width="100%," alt="Figure showing bubble plot of Pearson residuals with limited pattern except from not fitting decline as steeply in early years"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_residsflt1mkt0_page2.png",
+  caption = "Pearson residuals for lengths in the California trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red), males (blue), and unsexed (black)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals with limited pattern except from not fitting decline as steeply in early years.",
+  label = "fig:len-pearson1"
+)
+```
 
-![Mean length for the California trawl fleet with 95 percent confidence intervals based on current samples sizes for unsexed (top panel) and sexed (bottom panel) samples. \label{fig:mean-len-fit1}](../figures/plots/comp_lenfit_data_weighting_TA1.8_CA_TWL.png){width="100%," alt="Two panel figure with uncertainty around each point of mean length slightly decreasing in early years and stable since"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_data_weighting_TA1.8_CA_TWL.png",
+  caption = "Mean length for the California trawl fleet with 95 percent confidence intervals based on current samples sizes for unsexed (top panel) and sexed (bottom panel) samples",
+  alt_caption = "Two panel figure with uncertainty around each point of mean length slightly decreasing in early years and stable since.",
+  label = "fig:mean-len-fit1"
+)
+```
 
-![Pearson residuals for lengths in the Oregon trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected)for females (red) and males (blue). \label{fig:len-pearson2}](../figures/plots/comp_lenfit_residsflt2mkt0_page3.png){width="100%," alt="Figure showing bubble plot of Pearson residuals with limited pattern except from not fitting decline as steeply in early years"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_residsflt2mkt0_page3.png",
+  caption = "Pearson residuals for lengths in the Oregon trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected)for females (red) and males (blue)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals with limited pattern except from not fitting decline as steeply in early years.",
+  label = "fig:len-pearson2"
+)
+```
 
-![Mean length for the Oregon trawl fleet with 95 percent confidence intervals based on current samples sizes. \label{fig:mean-len-fit2}](../figures/plots/comp_lenfit_data_weighting_TA1.8_OR_TWL.png){width="100%," alt="Figure of mean length with uncertainty around each point showing a decrease early years, stable until 2010, and increasing since"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_data_weighting_TA1.8_OR_TWL.png",
+  caption = "Mean length for the Oregon trawl fleet with 95 percent confidence intervals based on current samples sizes",
+  alt_caption = "Figure of mean length with uncertainty around each point showing a decrease early years, stable until 2010, and increasing since.",
+  label = "fig:mean-len-fit2"
+)
+```
 
-![Pearson residuals for lengths in the Washington trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red), males (blue), and unsexed (black). \label{fig:len-pearson3}](../figures/plots/comp_lenfit_residsflt3mkt0_page3.png){width="100%," alt="Figure showing bubble plot of Pearson residuals with limited pattern"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_residsflt3mkt0_page3.png",
+  caption = "Pearson residuals for lengths in the Washington trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red), males (blue), and unsexed (black)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals with limited pattern.",
+  label = "fig:len-pearson3"
+)
+```
 
-![Mean length for the Washington trawl fleet with 95 percent confidence intervals based on current samples sizes for unsexed (top panel) and sexed (bottom panel) samples. \label{fig:mean-len-fit3}](../figures/plots/comp_lenfit_data_weighting_TA1.8_WA_TWL.png){width="100%," alt="Two panel figure with uncertainty around each point of mean length slightly decreasing in early years and stable since"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_data_weighting_TA1.8_WA_TWL.png",
+  caption = "Mean length for the Washington trawl fleet with 95 percent confidence intervals based on current samples sizes for unsexed (top panel) and sexed (bottom panel) samples",
+  alt_caption = "Two panel figure with uncertainty around each point of mean length slightly decreasing in early years and stable since.",
+  label = "fig:mean-len-fit3"
+)
+```
 
-![Pearson residuals for lengths in the California non-trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red), males (blue), and unsexed (black).  \label{fig:len-pearson4}](../figures/plots/comp_lenfit_residsflt4mkt0_page2.png){width="100%," alt="Figure showing bubble plot of Pearson residuals with limited pattern"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_residsflt4mkt0_page2.png",
+  caption = "Pearson residuals for lengths in the California non-trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red), males (blue), and unsexed (black).",
+  alt_caption = "Figure showing bubble plot of Pearson residuals with limited pattern.",
+  label = "fig:len-pearson4"
+)
+```
 
-![Mean length for the California non-trawl fleet with 95 percent confidence intervals based on current samples sizes for unsexed (top panel) and sexed (bottom panel) samples. \label{fig:mean-len-fit4}](../figures/plots/comp_lenfit_data_weighting_TA1.8_CA_NTWL.png){width="100%," alt="Two panel figure with uncertainty around each point of mean length changing little except an increase in the most recent years"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_data_weighting_TA1.8_CA_NTWL.png",
+  caption = "Mean length for the California non-trawl fleet with 95 percent confidence intervals based on current samples sizes for unsexed (top panel) and sexed (bottom panel) samples",
+  alt_caption = "Two panel figure with uncertainty around each point of mean length changing little except an increase in the most recent years.",
+  label = "fig:mean-len-fit4"
+)
+```
 
-![Pearson residuals for lengths in the Oregon non-trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red), males (blue), and unsexed (black). \label{fig:len-pearson5}](../figures/plots/comp_lenfit_residsflt5mkt0.png){width="100%," alt="Figure showing bubble plot of Pearson residuals with limited pattern and indicating bimodality in recent years"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_residsflt5mkt0.png",
+  caption = "Pearson residuals for lengths in the Oregon non-trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red), males (blue), and unsexed (black)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals with limited pattern and indicating bimodality in recent years.",
+  label = "fig:len-pearson5"
+)
+```
 
-![Mean length for the Oregon non-trawl fleet with 95 percent confidence intervals based on current samples sizes. \label{fig:mean-len-fit5}](../figures/plots/comp_lenfit_data_weighting_TA1.8_OR_NTWL.png){width="100%," alt="Figure with uncertainty around each point of sparse mean length data declining to 2000, experiencing a shift downward until 2020, after which length shifts upward"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_data_weighting_TA1.8_OR_NTWL.png",
+  caption = "Mean length for the Oregon non-trawl fleet with 95 percent confidence intervals based on current samples sizes",
+  alt_caption = "Figure with uncertainty around each point of sparse mean length data declining to 2000, experiencing a shift downward until 2020, after which length shifts upward.",
+  label = "fig:mean-len-fit5"
+)
+```
 
-![Pearson residuals for lengths in the Washington non-trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue). \label{fig:len-pearson6}](../figures/plots/comp_lenfit_residsflt6mkt0.png){width="100%," alt="Figure showing bubble plot of Pearson residuals with limited pattern"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_residsflt6mkt0.png",
+  caption = "Pearson residuals for lengths in the Washington non-trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals with limited pattern.",
+  label = "fig:len-pearson6"
+)
+```
 
-![Mean length for the Washington non-trawl fleet with 95 percent confidence intervals based on current samples sizes. \label{fig:mean-len-fit6}](../figures/plots/comp_lenfit_data_weighting_TA1.8_WA_NTWL.png){width="100%," alt="Figure with uncertainty around each point of sparse and variable mean length data"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_data_weighting_TA1.8_WA_NTWL.png",
+  caption = "Mean length for the Washington non-trawl fleet with 95 percent confidence intervals based on current samples sizes",
+  alt_caption = "Figure with uncertainty around each point of sparse and variable mean length data.",
+  label = "fig:mean-len-fit6"
+)
+```
 
-![Pearson residuals for lengths in the California recreational fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for unsexed (black). \label{fig:len-pearson7}](../figures/plots/comp_lenfit_residsflt7mkt0_page2.png){width="100%," alt="Figure showing bubble plot of Pearson residuals with limited pattern"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_residsflt7mkt0_page2.png",
+  caption = "Pearson residuals for lengths in the California recreational fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for unsexed (black)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals with limited pattern.",
+  label = "fig:len-pearson7"
+)
+```
 
-![Mean length for the California recreational fleet with 95 percent confidence intervals based on current samples sizes. \label{fig:mean-len-fit7}](../figures/plots/comp_lenfit_data_weighting_TA1.8_CA_REC.png){width="100%," alt="Figure with uncertainty around each point of mean length data that cycles over time"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_data_weighting_TA1.8_CA_REC.png",
+  caption = "Mean length for the California recreational fleet with 95 percent confidence intervals based on current samples sizes",
+  alt_caption = "Figure with uncertainty around each point of mean length data that cycles over time.",
+  label = "fig:mean-len-fit7"
+)
+```
 
-![Pearson residuals for lengths in the Oregon recreational fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red), males (blue), and unsexed (black). \label{fig:len-pearson8}](../figures/plots/comp_lenfit_residsflt8mkt0_page2.png){width="100%," alt="Figure showing bubble plot of Pearson residuals with limited pattern excpet for some underfitting of large length between 1992 and 2008"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_residsflt8mkt0_page2.png",
+  caption = "Pearson residuals for lengths in the Oregon recreational fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red), males (blue), and unsexed (black)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals with limited pattern excpet for some underfitting of large length between 1992 and 2008.",
+  label = "fig:len-pearson8"
+)
+```
 
-![Mean length for the Oregon recreational fleet with 95 percent confidence intervals based on current samples sizes for unsexed (top panel) and sexed (bottom panel) samples. \label{fig:mean-len-fit8}](../figures/plots/comp_lenfit_data_weighting_TA1.8_OR_REC.png){width="100%," alt="Two panel figure with uncertainty around each point of mean length that is variable and slightly increasing over time"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_data_weighting_TA1.8_OR_REC.png",
+  caption = "Mean length for the Oregon recreational fleet with 95 percent confidence intervals based on current samples sizes for unsexed (top panel) and sexed (bottom panel) samples",
+  alt_caption = "Two panel figure with uncertainty around each point of mean length that is variable and slightly increasing over time.",
+  label = "fig:mean-len-fit8"
+)
+```
 
-![Pearson residuals for lengths in the Washington recreational fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red), males (blue), and unsexed (black). \label{fig:len-pearson9}](../figures/plots/comp_lenfit_residsflt9mkt0_page2.png){width="100%," alt="Figure showing bubble plot of Pearson residuals with limited pattern and indicating bimodality in recent years"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_residsflt9mkt0_page2.png",
+  caption = "Pearson residuals for lengths in the Washington recreational fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red), males (blue), and unsexed (black)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals with limited pattern and indicating bimodality in recent years.",
+  label = "fig:len-pearson9"
+)
+```
 
-![Mean length for the Washington recreational fleet with 95 percent confidence intervals based on current samples sizes for unsexed (top panel) and sexed (bottom panel) samples. \label{fig:mean-len-fit9}](../figures/plots/comp_lenfit_data_weighting_TA1.8_WA_REC.png){width="100%," alt="Two panel figure with uncertainty around each point of mean length that is generally unchanging over time with an increase in recent years"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_data_weighting_TA1.8_WA_REC.png",
+  caption = "Mean length for the Washington recreational fleet with 95 percent confidence intervals based on current samples sizes for unsexed (top panel) and sexed (bottom panel) samples",
+  alt_caption = "Two panel figure with uncertainty around each point of mean length that is generally unchanging over time with an increase in recent years.",
+  label = "fig:mean-len-fit9"
+)
+```
 
-![Pearson residuals for lengths in the Oregon at-sea hake fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue). \label{fig:len-pearson11}](../figures/plots/comp_lenfit_residsflt11mkt0.png){width="100%," alt="Figure showing bubble plot of Pearson residuals with limited pattern"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_residsflt11mkt0.png",
+  caption = "Pearson residuals for lengths in the Oregon at-sea hake fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals with limited pattern.",
+  label = "fig:len-pearson11"
+)
+```
 
-![Mean length for the Oregon at-sea hake fleet with 95 percent confidence intervals based on current samples sizes. \label{fig:mean-len-fit11}](../figures/plots/comp_lenfit_data_weighting_TA1.8_OR_ASHOP.png){width="100%," alt="Figure with uncertainty around each point of mean length that is unchanging over time"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_data_weighting_TA1.8_OR_ASHOP.png",
+  caption = "Mean length for the Oregon at-sea hake fleet with 95 percent confidence intervals based on current samples sizes",
+  alt_caption = "Figure with uncertainty around each point of mean length that is unchanging over time.",
+  label = "fig:mean-len-fit11"
+)
+```
 
-![Pearson residuals for lengths in the Washington at-sea hake fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females(red) and males (blue). \label{fig:len-pearson12}](../figures/plots/comp_lenfit_residsflt12mkt0.png){width="100%," alt="Figure showing bubble plot of Pearson residuals with underfitting of larger lengths in the early 2000s"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_residsflt12mkt0.png",
+  caption = "Pearson residuals for lengths in the Washington at-sea hake fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females(red) and males (blue)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals with underfitting of larger lengths in the early 2000s.",
+  label = "fig:len-pearson12"
+)
+```
 
-![Mean length for the Washington at-sea hake fleet with 95 percent confidence intervals based on current samples. \label{fig:mean-len-fit12}](../figures/plots/comp_lenfit_data_weighting_TA1.8_WA_ASHOP.png){width="100%," alt="Figure with uncertainty around each point of mean length that is unchanging over time"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_data_weighting_TA1.8_WA_ASHOP.png",
+  caption = "Mean length for the Washington at-sea hake fleet with 95 percent confidence intervals based on current samples",
+  alt_caption = "Figure with uncertainty around each point of mean length that is unchanging over time.",
+  label = "fig:mean-len-fit12"
+)
+```
 
-![Pearson residuals for lengths in the West Coast Groundfish Bottomtrawl Survey. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue). \label{fig:len-pearson28}](../figures/plots/comp_lenfit_residsflt28mkt0.png){width="100%," alt="Figure showing bubble plot of Pearson residuals with limited pattern"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_residsflt28mkt0.png",
+  caption = "Pearson residuals for lengths in the West Coast Groundfish Bottomtrawl Survey. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals with limited pattern.",
+  label = "fig:len-pearson28"
+)
+```
 
-![Mean length for the West Coast Groundfish Bottomtrawl Survey with 95 percent confidence intervals based on current samples. \label{fig:mean-len-fit28}](../figures/plots/comp_lenfit_data_weighting_TA1.8_WCGBTS.png){width="100%," alt="Figure with uncertainty around each point of mean length that is variable but non-trending over time"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_data_weighting_TA1.8_WCGBTS.png",
+  caption = "Mean length for the West Coast Groundfish Bottomtrawl Survey with 95 percent confidence intervals based on current samples",
+  alt_caption = "Figure with uncertainty around each point of mean length that is variable but non-trending over time.",
+  label = "fig:mean-len-fit28"
+)
+```
 
-![Pearson residuals for lengths in the early Triennial Survey. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue). \label{fig:len-pearson29}](../figures/plots/comp_lenfit_residsflt29mkt0.png){width="100%," alt="Figure showing bubble plot of Pearson residuals with limited pattern"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_residsflt29mkt0.png",
+  caption = "Pearson residuals for lengths in the early Triennial Survey. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals with limited pattern.",
+  label = "fig:len-pearson29"
+)
+```
 
-![Mean length for the early Triennial Survey with 95 percent confidence intervals based on current samples. \label{fig:mean-len-fit29}](../figures/plots/comp_lenfit_data_weighting_TA1.8_Tri_early.png){width="100%," alt="Figure with uncertainty around each point of mean length that is declining over time"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_data_weighting_TA1.8_Tri_early.png",
+  caption = "Mean length for the early Triennial Survey with 95 percent confidence intervals based on current samples",
+  alt_caption = "Figure with uncertainty around each point of mean length that is declining over time.",
+  label = "fig:mean-len-fit29"
+)
+```
 
-![Pearson residuals for lengths in the late Triennial Survey. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue). \label{fig:len-pearson30}](../figures/plots/comp_lenfit_residsflt30mkt0.png){width="100%," alt="Figure showing bubble plot of Pearson residuals with limited pattern"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_residsflt30mkt0.png",
+  caption = "Pearson residuals for lengths in the late Triennial Survey. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals with limited pattern.",
+  label = "fig:len-pearson30"
+)
+```
 
-![Mean length for the late Triennial Survey with 95 percent confidence intervals based on current samples. \label{fig:mean-len-fit30}](../figures/plots/comp_lenfit_data_weighting_TA1.8_Tri_late.png){width="100%," alt="Figure with uncertainty around each point of mean length that is increasing over time"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_lenfit_data_weighting_TA1.8_Tri_late.png",
+  caption = "Mean length for the late Triennial Survey with 95 percent confidence intervals based on current samples",
+  alt_caption = "Figure with uncertainty around each point of mean length that is increasing over time.",
+  label = "fig:mean-len-fit30"
+)
+```
 
 <!-- #### Age compositions -->
 
-![Age composition aggregated across years by fleet with the model estimated fit to the data by sex (red female, and blue male). \label{fig:age-agg-fit}](../figures/plots/comp_agefit__aggregated_across_time.png){width="100%," alt="Figure showing fits of modeled age composition for all fleets generally matching the distribution observed in the data"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit__aggregated_across_time.png",
+  caption = "Age composition aggregated across years by fleet with the model estimated fit to the data by sex (red female, and blue male)",
+  alt_caption = "Figure showing fits of modeled age composition for all fleets generally matching the distribution observed in the data.",
+  label = "fig:age-agg-fit"
+)
+```
 
-![Pearson residuals for ages in the California trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue). \label{fig:age-pearson1}](../figures/plots/comp_agefit_residsflt1mkt0_page2.png){width="100%," alt="Figure showing bubble plot of Pearson residuals with limited pattern except from not fitting decline as steeply in early years"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit_residsflt1mkt0_page2.png",
+  caption = "Pearson residuals for ages in the California trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals with limited pattern except from not fitting decline as steeply in early years.",
+  label = "fig:age-pearson1"
+)
+```
 
-![Mean age for the California trawl fleet with 95 percent confidence intervals based on current samples sizes. \label{fig:mean-age-fit1}](../figures/plots/comp_agefit_data_weighting_TA1.8_CA_TWL.png){width="100%," alt="Figure with uncertainty around each point of mean age which is slightly higher in early years compared to later years"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit_data_weighting_TA1.8_CA_TWL.png",
+  caption = "Mean age for the California trawl fleet with 95 percent confidence intervals based on current samples sizes",
+  alt_caption = "Figure with uncertainty around each point of mean age which is slightly higher in early years compared to later years.",
+  label = "fig:mean-age-fit1"
+)
+```
 
-![Pearson residuals for ages in the Oregon trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue). \label{fig:age-pearson2}](../figures/plots/comp_agefit_residsflt2mkt0_page2.png){width="100%," alt="Figure showing bubble plot of Pearson residuals with underfitting old samples in the early and recent years"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit_residsflt2mkt0_page2.png",
+  caption = "Pearson residuals for ages in the Oregon trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals with underfitting old samples in the early and recent years.",
+  label = "fig:age-pearson2"
+)
+```
 
-![Mean age for the Oregon trawl fleet with 95 percent confidence intervals based on current samples sizes. \label{fig:mean-age-fit2}](../figures/plots/comp_agefit_data_weighting_TA1.8_OR_TWL.png){width="100%," alt="Figure with uncertainty around each point of mean age higher in early years compared to later years"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit_data_weighting_TA1.8_OR_TWL.png",
+  caption = "Mean age for the Oregon trawl fleet with 95 percent confidence intervals based on current samples sizes",
+  alt_caption = "Figure with uncertainty around each point of mean age higher in early years compared to later years.",
+  label = "fig:mean-age-fit2"
+)
+```
 
-![Pearson residuals for ages in the Washington trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue). \label{fig:age-pearson3}](../figures/plots/comp_agefit_residsflt3mkt0_page3.png){width="100%," alt="Figure showing bubble plot of Pearson residuals with overfitting of young samples in the early and years and underfitting moderatlely old samples in the 2000s"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit_residsflt3mkt0_page3.png",
+  caption = "Pearson residuals for ages in the Washington trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals with overfitting of young samples in the early and years and underfitting moderatlely old samples in the 2000s.",
+  label = "fig:age-pearson3"
+)
+```
 
-![Mean age for the Washington trawl fleet with 95 percent confidence intervals based on current samples sizes. \label{fig:mean-age-fit3}](../figures/plots/comp_agefit_data_weighting_TA1.8_WA_TWL.png){width="100%," alt="Figure with uncertainty around each point of mean age that is variabilty and cycles over time"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit_data_weighting_TA1.8_WA_TWL.png",
+  caption = "Mean age for the Washington trawl fleet with 95 percent confidence intervals based on current samples sizes",
+  alt_caption = "Figure with uncertainty around each point of mean age that is variabilty and cycles over time.",
+  label = "fig:mean-age-fit3"
+)
+```
 
-![Pearson residuals for ages in the California non-trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue). \label{fig:age-pearson4}](../figures/plots/comp_agefit_residsflt4mkt0.png){width="100%," alt="Figure showing bubble plot of Pearson residuals from sparse samples"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit_residsflt4mkt0.png",
+  caption = "Pearson residuals for ages in the California non-trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals from sparse samples.",
+  label = "fig:age-pearson4"
+)
+```
 
-![Mean age for the California non-trawl fleet with 95 percent confidence intervals based on current samples sizes. \label{fig:mean-age-fit4}](../figures/plots/comp_agefit_data_weighting_TA1.8_CA_NTWL.png){width="100%," alt="Figure with uncertainty around each point of mean age which is variable and from sparse samples"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit_data_weighting_TA1.8_CA_NTWL.png",
+  caption = "Mean age for the California non-trawl fleet with 95 percent confidence intervals based on current samples sizes",
+  alt_caption = "Figure with uncertainty around each point of mean age which is variable and from sparse samples.",
+  label = "fig:mean-age-fit4"
+)
+```
 
-![Pearson residuals for ages in the Oregon non-trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue). \label{fig:age-pearson5}](../figures/plots/comp_agefit_residsflt5mkt0.png){width="100%," alt="Figure showing bubble plot of Pearson residuals from sparse samples"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit_residsflt5mkt0.png",
+  caption = "Pearson residuals for ages in the Oregon non-trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals from sparse samples.",
+  label = "fig:age-pearson5"
+)
+```
 
-![Mean age for the Oregon non-trawl fleet with 95 percent confidence intervals based on current samples sizes. \label{fig:mean-age-fit5}](../figures/plots/comp_agefit_data_weighting_TA1.8_OR_NTWL.png){width="100%," alt="Figure with uncertainty around each point of mean age which is variable and from sparse samples"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit_data_weighting_TA1.8_OR_NTWL.png",
+  caption = "Mean age for the Oregon non-trawl fleet with 95 percent confidence intervals based on current samples sizes",
+  alt_caption = "Figure with uncertainty around each point of mean age which is variable and from sparse samples.",
+  label = "fig:mean-age-fit5"
+)
+```
 
-![Pearson residuals for ages in the Washington non-trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue). \label{fig:age-pearson6}](../figures/plots/comp_agefit_residsflt6mkt0.png){width="100%," alt="Figure showing bubble plot of Pearson residuals without trends"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit_residsflt6mkt0.png",
+  caption = "Pearson residuals for ages in the Washington non-trawl fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals without trends.",
+  label = "fig:age-pearson6"
+)
+```
 
-![Mean age for the Washington non-trawl fleet with 95 percent confidence intervals based on current samples sizes. \label{fig:mean-age-fit6}](../figures/plots/comp_agefit_data_weighting_TA1.8_WA_NTWL.png){width="100%," alt="Figure with uncertainty around each point of mean age that is variable and without trend"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit_data_weighting_TA1.8_WA_NTWL.png",
+  caption = "Mean age for the Washington non-trawl fleet with 95 percent confidence intervals based on current samples sizes",
+  alt_caption = "Figure with uncertainty around each point of mean age that is variable and without trend.",
+  label = "fig:mean-age-fit6"
+)
+```
 
-![Pearson residuals for ages in the Oregon recreational fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue). \label{fig:age-pearson8}](../figures/plots/comp_agefit_residsflt8mkt0.png){width="100%," alt="Figure showing bubble plot of Pearson residuals underfitting older ages in recent years"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit_residsflt8mkt0.png",
+  caption = "Pearson residuals for ages in the Oregon recreational fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals underfitting older ages in recent years.",
+  label = "fig:age-pearson8"
+)
+```
 
-![Mean age for the Oregon recreational fleet with 95 percent confidence intervals based on current samples sizes. \label{fig:mean-age-fit8}](../figures/plots/comp_agefit_data_weighting_TA1.8_OR_REC.png){width="100%," alt="Figure with uncertainty around each point of mean age which shows an increase in recent years"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit_data_weighting_TA1.8_OR_REC.png",
+  caption = "Mean age for the Oregon recreational fleet with 95 percent confidence intervals based on current samples sizes",
+  alt_caption = "Figure with uncertainty around each point of mean age which shows an increase in recent years.",
+  label = "fig:mean-age-fit8"
+)
+```
 
-![Pearson residuals for ages in the Washington recreational fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue). \label{fig:age-pearson9}](../figures/plots/comp_agefit_residsflt9mkt0.png){width="100%," alt="Figure showing bubble plot of Pearson residuals overfitting younger ages"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit_residsflt9mkt0.png",
+  caption = "Pearson residuals for ages in the Washington recreational fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals overfitting younger ages.",
+  label = "fig:age-pearson9"
+)
+```
 
-![Mean age for the Washington recreational fleet with 95 percent confidence intervals based on current samples sizes. \label{fig:mean-age-fit9}](../figures/plots/comp_agefit_data_weighting_TA1.8_WA_REC.png){width="100%," alt="Figure with uncertainty around each point of mean age which shows no trend until 2020 at which point mean age steps up to older ages"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit_data_weighting_TA1.8_WA_REC.png",
+  caption = "Mean age for the Washington recreational fleet with 95 percent confidence intervals based on current samples sizes",
+  alt_caption = "Figure with uncertainty around each point of mean age which shows no trend until 2020 at which point mean age steps up to older ages.",
+  label = "fig:mean-age-fit9"
+)
+```
 
-![Pearson residuals for ages in the Oregon at-sea hake fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue). \label{fig:age-pearson11}](../figures/plots/comp_agefit_residsflt11mkt0.png){width="100%," alt="Figure showing bubble plot of Pearson residuals with little trend"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit_residsflt11mkt0.png",
+  caption = "Pearson residuals for ages in the Oregon at-sea hake fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals with little trend.",
+  label = "fig:age-pearson11"
+)
+```
 
-![Mean age for the Oregon at-sea hake fleet with 95 percent confidence intervals based on current samples sizes. \label{fig:mean-age-fit11}](../figures/plots/comp_agefit_data_weighting_TA1.8_OR_ASHOP.png){width="100%," alt="Figure with uncertainty around each point of mean age which shows no trend"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit_data_weighting_TA1.8_OR_ASHOP.png",
+  caption = "Mean age for the Oregon at-sea hake fleet with 95 percent confidence intervals based on current samples sizes",
+  alt_caption = "Figure with uncertainty around each point of mean age which shows no trend.",
+  label = "fig:mean-age-fit11"
+)
+```
 
-![Pearson residuals for ages in the Washington at-sea hake fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue). \label{fig:age-pearson12}](../figures/plots/comp_agefit_residsflt12mkt0.png){width="100%," alt="Figure showing bubble plot of Pearson residuals with little trend"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit_residsflt12mkt0.png",
+  caption = "Pearson residuals for ages in the Washington at-sea hake fleet. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) for females (red) and males (blue)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals with little trend.",
+  label = "fig:age-pearson12"
+)
+```
 
-![Mean age for the Washington at-sea hake fleet with 95 percent confidence intervals based on current samples sizes. \label{fig:mean-age-fit12}](../figures/plots/comp_agefit_data_weighting_TA1.8_WA_ASHOP.png){width="100%," alt="Figure with uncertainty around each point of mean age which shows no trend"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_agefit_data_weighting_TA1.8_WA_ASHOP.png",
+  caption = "Mean age for the Washington at-sea hake fleet with 95 percent confidence intervals based on current samples sizes",
+  alt_caption = "Figure with uncertainty around each point of mean age which shows no trend.",
+  label = "fig:mean-age-fit12"
+)
+```
 
 <!-- #### Conditional age at length compositions -->
 
-![Pearson residuals for conditional age-at-length in the West Coast Groundfish Bottomtrawl Survey (plot 1 of 2). Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) and are separate for each sex (red female, and blue male). \label{fig:caal-pearson28_1}](../figures/comp_condAALfit_residsflt28mkt0_page1_custom.png){width="100%," alt="Figure showing bubble plot of Pearson residuals for males and females with pattern shaped like the age-length relationship for years 2003-2012"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/comp_condAALfit_residsflt28mkt0_page1_custom.png",
+  caption = "Pearson residuals for conditional age-at-length in the West Coast Groundfish Bottomtrawl Survey (plot 1 of 2). Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) and are separate for each sex (red female, and blue male)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals for males and females with pattern shaped like the age-length relationship for years 2003-2012.",
+  label = "fig:caal-pearson28_1"
+)
+```
 
-![Pearson residuals for conditional age-at-length in the West Coast Groundfish Bottomtrawl Survey (plot 2 of 2). Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) and are separate for each sex (red female, and blue male). \label{fig:caal-pearson28_2}](../figures/comp_condAALfit_residsflt28mkt0_page2_custom.png){width="100%," alt="Figure showing bubble plot of Pearson residuals for males and females with pattern shaped like the age-length relationship for years 2013-2022"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/comp_condAALfit_residsflt28mkt0_page2_custom.png",
+  caption = "Pearson residuals for conditional age-at-length in the West Coast Groundfish Bottomtrawl Survey (plot 2 of 2). Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) and are separate for each sex (red female, and blue male)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals for males and females with pattern shaped like the age-length relationship for years 2013-2022.",
+  label = "fig:caal-pearson28_2"
+)
+```
 
-![Pearson residuals for conditional age-at-length in the early Triennial survey. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) and are separate for each sex (red female, and blue male). \label{fig:caal-pearson29}](../figures/plots/comp_condAALfit_residsflt29mkt0.png){width="100%," alt="Figure showing bubble plot of Pearson residuals for males and females with pattern shaped like the age-length relationship for years 1980-1992"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_condAALfit_residsflt29mkt0.png",
+  caption = "Pearson residuals for conditional age-at-length in the early Triennial survey. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) and are separate for each sex (red female, and blue male)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals for males and females with pattern shaped like the age-length relationship for years 1980-1992.",
+  label = "fig:caal-pearson29"
+)
+```
 
-![Pearson residuals for conditional age-at-length in the late Triennial survey. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) and are separate for each sex (red female, and blue male). \label{fig:caal-pearson30}](../figures/plots/comp_condAALfit_residsflt30mkt0.png){width="100%," alt="Figure showing bubble plot of Pearson residuals for males and females with pattern shaped like the age-length relationship for years 1996-2004"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/comp_condAALfit_residsflt30mkt0.png",
+  caption = "Pearson residuals for conditional age-at-length in the late Triennial survey. Closed bubbles are positive residuals (observed \> expected) and open bubbles are negative residuals (observed \< expected) and are separate for each sex (red female, and blue male)",
+  alt_caption = "Figure showing bubble plot of Pearson residuals for males and females with pattern shaped like the age-length relationship for years 1996-2004.",
+  label = "fig:caal-pearson30"
+)
+```
 
 <!-- #### Survey indices -->
 
-![Fit of model to \gls{s-wcgbt}. Lines represent input 95 percent confidence interval of survey index. \label{fig:wcgbts-fit}](../figures/plots/index2_cpuefit_WCGBTS.png){width="100%," height="100%," alt="Figure showing model generally fitting survey data well"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/index2_cpuefit_WCGBTS.png",
+  caption = "Fit of model to \gls{s-wcgbt}. Lines represent input 95 percent confidence interval of survey index",
+  alt_caption = "Figure showing model generally fitting survey data well.",
+  label = "fig:wcgbts-fit"
+)
+```
 
-![Fit of model to early \gls{s-tri}. Lines represent input 95 percent confidence interval of survey index. \label{fig:earlytri-fit}](../figures/plots/index2_cpuefit_Tri_early.png){width="100%," height="100%," alt="Figure showing model over and then underestimating first two out of five years of generally declining survey index"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/index2_cpuefit_Tri_early.png",
+  caption = "Fit of model to early \gls{s-tri}. Lines represent input 95 percent confidence interval of survey index",
+  alt_caption = "Figure showing model over and then underestimating first two out of five years of generally declining survey index.",
+  label = "fig:earlytri-fit"
+)
+```
 
-![Fit of model to late \gls{s-tri}. Lines represent input 95 percent confidence interval of survey index. \label{fig:latetri-fit}](../figures/plots/index2_cpuefit_Tri_late.png){width="100%," height="100%," alt="Figure showing model very well fitting slow increase of survey index"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/index2_cpuefit_Tri_late.png",
+  caption = "Fit of model to late \gls{s-tri}. Lines represent input 95 percent confidence interval of survey index",
+  alt_caption = "Figure showing model very well fitting slow increase of survey index.",
+  label = "fig:latetri-fit"
+)
+```
 
-![Fit of model to log of pre-recruit survey index. Log scale is shown because model fits were difficult to evaluate on absolute index scale. Thick lines represent input 95 percent confidence intervals. Thin lines are 95% confidence intervals including estimated added survey standard deviation. \label{fig:prerec-fit}](../figures/plots/index5_logcpuefit_prerec){width="100%," height="100%," alt="Figure showing model fits annually variable index very well with added standard error included"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/index5_logcpuefit_prerec",
+  caption = "Fit of model to log of pre-recruit survey index. Log scale is shown because model fits were difficult to evaluate on absolute index scale. Thick lines represent input 95 percent confidence intervals. Thin lines are 95 percent confidence intervals including estimated added survey standard deviation",
+  alt_caption = "Figure showing model fits annually variable index very well with added standard error included.",
+  label = "fig:prerec-fit"
+)
+```
 
 ### Time series
 
-![Estimated time series of spawning output in million of eggs with 95% confidence interval. \label{fig:ssb}](../figures/plots/ts7_Spawning_output_with_95_asymptotic_intervals_intervals.png){width="100%," alt="Figure showing lowering of spawning output into 1990s and slow increase since"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/ts7_Spawning_output_with_95_asymptotic_intervals_intervals.png",
+  caption = "Estimated time series of spawning output in million of eggs with 95 percent confidence interval",
+  alt_caption = "Figure showing lowering of spawning output into 1990s and slow increase since.",
+  label = "fig:ssb"
+)
+```
 
-![Estimated time series of total biomass in mt. \label{fig:tot-bio}](../figures/plots/ts1_Total_biomass_(mt).png){width="100%," alt="Figure showing total biomass similar in pattern to spawning output"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/ts1_Total_biomass_(mt).png",
+  caption = "Estimated time series of total biomass in mt",
+  alt_caption = "Figure showing total biomass similar in pattern to spawning output.",
+  label = "fig:tot-bio"
+)
+```
 
-![Estimated time series of spawning output relative to unfished with 95% confidence interval. \label{fig:depl}](../figures/plots/ts9_Relative_spawning_output_intervals.png){width="100%," alt="Figure showing similar trends to spawning output surpassing the 0.4 target around 1980, going below the 0.25 threshold shortly thereafter, and then recovering to between the threshold and target starting in around 2015"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/ts9_Relative_spawning_output_intervals.png",
+  caption = "Estimated time series of spawning output relative to unfished with 95 percent confidence interval",
+  alt_caption = "Figure showing similar trends to spawning output surpassing the 0.4 target around 1980, going below the 0.25 threshold shortly thereafter, and then recovering to between the threshold and target starting in around 2015.",
+  label = "fig:depl"
+)
+```
 
-![Estimated time series of fishing intensity (1-SPR). \label{fig:spr}](../figures/plots/SPR2_minusSPRseries.png){width="100%," alt="Figure showing fishing intensity increasing in the 1940, surpassing 0.5 consistently in the 1960s, declining greatly in 2000 and reching near 0.4 in 2022"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/SPR2_minusSPRseries.png",
+  caption = "Estimated time series of fishing intensity (1-SPR)",
+  alt_caption = "Figure showing fishing intensity increasing in the 1940, surpassing 0.5 consistently in the 1960s, declining greatly in 2000 and reching near 0.4 in 2022.",
+  label = "fig:spr"
+)
+```
 
 ## Diagnostics
 
-![Comparison of the relative change in estimated management quantities as compared to the base model for structural sensitivities. The quantities compared are 1) the estimate of unfished spawning output (SB~0~), spawning output in 2023 (SB~2023~), the relative spawning output in 2023 (SB~2023~/SB~0~), the yield resulting in a population at a spawning potential ratio of 0.5 (Yield~SPR=0.50~), and the fishing mortality associated with that yield (F~SPR=0.50~). The thick lines at the top indicate the 95 percent confidence interval around the point estimate of the quantity from the base model, where each color corresponds with a specific quantity in the legend. Values to the right of the vertical dashed line indicate the quantity was estimated higher than in the base model, whereas values to the left indicate the quantity was estimated lower. \label{fig:sens-summary}](../figures/sensitivities/sens_summary.png){width="100%," alt="Figure summarizing how estimates of derived quantities differ between sensitivity models and base model and increasing francis age and length weights result in the largest changes and most other quantities fall within the 95% confidence intervals for the respective derived quantities"}
-
-![Comparison of spawning output for data sensitivities. Scenarios are described in section \@ref(data-choices). Blue band represents 95% confidence interval from the base model. \label{fig:data-ssb-compare}](../figures/sensitivities/datacompare2_spawnbio_uncertainty.png){width="100%," alt="Figure showing spawning output for all data sensitivities is similar to the base model except for adding Canadian catches, which results in a higher overall population scale"}
-
-![Comparison of spawning output relative to unfished for data sensitivities. Scenarios are described in section \@ref(data-choices). Blue band represents 95% confidence interval from the base model. \label{fig:data-bratio-compare}](../figures/sensitivities/datacompare4_Bratio_uncertainty.png){width="100%," alt="Figure showing spawning output for all data sensitivities is similar to the base model"}
-
-![Comparison of spawning output for data weighting sensitivities. Scenarios are described in section \@ref(data-weighting). Blue band represents 95% confidence interval from the base model. \label{fig:weight-ssb-compare}](../figures/sensitivities/weightingcompare2_spawnbio_uncertainty.png){width="100%," alt="Figure showing major differences in spawning output when increasing length or age weights relative to the base model"}
-
-![Comparison of spawning output relative to unfished for data weighting sensitivities. Scenarios are described in section \@ref(data-weighting). Blue band represents 95% confidence interval from the base model. \label{fig:weight-bratio-compare}](../figures/sensitivities/weightingcompare4_Bratio_uncertainty.png){width="100%," alt="Figure showing spawning output for all data sensitivities is similar to the base model except for adding Canadian catches, which results in a higher overall population scale"}
-
-![Comparison of spawning output for selectivity and catchability sensitivities. Scenarios are described in section \@ref(selectivity-and-catchability). Blue band represents 95% confidence interval from the base model. \label{fig:selec-ssb-compare}](../figures/sensitivities/selectivitycompare2_spawnbio_uncertainty.png){width="100%," alt="Figure showing no sex selectivity leads to major increase in spawning output early in the time series"}
-
-![Comparison of spawning output relative to unfished for selectivity and catchability sensitivities. Scenarios are described in section \@ref(selectivity-and-catchability). Blue band represents 95% confidence interval from the base model. \label{fig:selec-bratio-compare}](../figures/sensitivities/selectivitycompare4_Bratio_uncertainty.png){width="100%," alt="Figure showing no sex selectivity leads to much lower present-day depletion below the minimum size size threshold"}
-
-![Comparison of spawning output for productivity sensitivities. Scenarios are described in section \@ref(population-productivity). Blue band represents 95% confidence interval from the base model. \label{fig:prod-ssb-compare}](../figures/sensitivities/productivitycompare2_spawnbio_uncertainty.png){width="100%," alt="Figure showing spawning output changes most with a single natural mortality rate where historical spawning output is higher, and estimating male natural mortality, where present-day spawning output is higher"}
-
-![Comparison of spawning output relative to unfished for productivity sensitivities. Scenarios are described in section \@ref(population-productivity). Blue band represents 95% confidence interval from the base model. \label{fig:prod-bratio-compare}](../figures/sensitivities/productivitycompare4_Bratio_uncertainty.png){width="100%," alt="Figure showing present-day spawning depletion is much higher for most structural senstivities related to productivity, except for a single natural mortality which has much lower depletion"}
-
-```{r, results = 'asis'}
+```{r, results = "asis"}
 sa4ss::add_figure(
-filein = here("models/7_3_5_reweight_retro", "compare2_spawnbio_uncertainty.png"), 
+  filein = "../figures/sensitivities/sens_summary.png",
+  caption = "Comparison of the relative change in estimated management quantities as compared to the base model for structural sensitivities. The quantities compared are 1) the estimate of unfished spawning output (SB$_{0}$), spawning output in 2023 (SB$_{2023}$), the relative spawning output in 2023 (SB$_{2023}$/SB$_{0}$), the yield resulting in a population at a spawning potential ratio of 0.5 (Yield$_{SPR=0.50}$), and the fishing mortality associated with that yield (F$_{SPR=0.50}$). The thick lines at the top indicate the 95 percent confidence interval around the point estimate of the quantity from the base model, where each color corresponds with a specific quantity in the legend. Values to the right of the vertical dashed line indicate the quantity was estimated higher than in the base model, whereas values to the left indicate the quantity was estimated lower",
+  alt_caption = "Figure summarizing how estimates of derived quantities differ between sensitivity models and base model and increasing francis age and length weights result in the largest changes and most other quantities fall within the 95 percent confidence intervals for the respective derived quantities.",
+  label = "fig:sens-summary"
+)
+```
+
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/sensitivities/datacompare2_spawnbio_uncertainty.png",
+  caption = "Comparison of spawning output for data sensitivities. Scenarios are described in section \@ref(data-choices). Blue band represents 95 percent confidence interval from the base model",
+  alt_caption = "Figure showing spawning output for all data sensitivities is similar to the base model except for adding Canadian catches, which results in a higher overall population scale.",
+  label = "fig:data-ssb-compare"
+)
+```
+
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/sensitivities/datacompare4_Bratio_uncertainty.png",
+  caption = "Comparison of spawning output relative to unfished for data sensitivities. Scenarios are described in section \@ref(data-choices). Blue band represents 95 percent confidence interval from the base model",
+  alt_caption = "Figure showing spawning output for all data sensitivities is similar to the base model.",
+  label = "fig:data-bratio-compare"
+)
+```
+
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/sensitivities/weightingcompare2_spawnbio_uncertainty.png",
+  caption = "Comparison of spawning output for data weighting sensitivities. Scenarios are described in section \@ref(data-weighting). Blue band represents 95 percent confidence interval from the base model",
+  alt_caption = "Figure showing major differences in spawning output when increasing length or age weights relative to the base model.",
+  label = "fig:weight-ssb-compare"
+)
+```
+
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/sensitivities/weightingcompare4_Bratio_uncertainty.png",
+  caption = "Comparison of spawning output relative to unfished for data weighting sensitivities. Scenarios are described in section \@ref(data-weighting). Blue band represents 95 percent confidence interval from the base model",
+  alt_caption = "Figure showing spawning output for all data sensitivities is similar to the base model except for adding Canadian catches, which results in a higher overall population scale.",
+  label = "fig:weight-bratio-compare"
+)
+```
+
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/sensitivities/selectivitycompare2_spawnbio_uncertainty.png",
+  caption = "Comparison of spawning output for selectivity and catchability sensitivities. Scenarios are described in section \@ref(selectivity-and-catchability). Blue band represents 95 percent confidence interval from the base model",
+  alt_caption = "Figure showing no sex selectivity leads to major increase in spawning output early in the time series.",
+  label = "fig:selec-ssb-compare"
+)
+```
+
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/sensitivities/selectivitycompare4_Bratio_uncertainty.png",
+  caption = "Comparison of spawning output relative to unfished for selectivity and catchability sensitivities. Scenarios are described in section \@ref(selectivity-and-catchability). Blue band represents 95 percent confidence interval from the base model",
+  alt_caption = "Figure showing no sex selectivity leads to much lower present-day depletion below the minimum size size threshold.",
+  label = "fig:selec-bratio-compare"
+)
+```
+
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/sensitivities/productivitycompare2_spawnbio_uncertainty.png",
+  caption = "Comparison of spawning output for productivity sensitivities. Scenarios are described in section \@ref(population-productivity). Blue band represents 95 percent confidence interval from the base model",
+  alt_caption = "Figure showing spawning output changes most with a single natural mortality rate where historical spawning output is higher, and estimating male natural mortality, where present-day spawning output is higher.",
+  label = "fig:prod-ssb-compare"
+)
+```
+
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/sensitivities/productivitycompare4_Bratio_uncertainty.png",
+  caption = "Comparison of spawning output relative to unfished for productivity sensitivities. Scenarios are described in section \@ref(population-productivity). Blue band represents 95 percent confidence interval from the base model",
+  alt_caption = "Figure showing present-day spawning depletion is much higher for most structural senstivities related to productivity, except for a single natural mortality which has much lower depletion.",
+  label = "fig:prod-bratio-compare"
+)
+```
+
+```{r, results = "asis"}
+sa4ss::add_figure(
+filein = here::here("models/7_3_5_reweight_retro", "compare2_spawnbio_uncertainty.png"), 
 caption = "Change in spawning output when the most recent five years of data are sequentially removed from the model",
-alt_caption = "Figure showing five retrospective runs with slightly lower estimates of initial and ending spawning output compared to the base model",
+alt_caption = "Figure showing five retrospective runs with slightly lower estimates of initial and ending spawning output compared to the base model.",
 label = 'retro_bio')
 ```
 
-```{r, results = 'asis'}
+```{r, results = "asis"}
 sa4ss::add_figure(
-filein = here("models/7_3_5_reweight_retro", "compare4_Bratio_uncertainty.png"), 
+filein = here::here("models/7_3_5_reweight_retro", "compare4_Bratio_uncertainty.png"), 
 caption = "Change in spawning output relative to unfished when the most recent five years of data are sequentially removed from the model",
-alt_caption = "Figure showing five retrospective runs with similar estimates for fraction of unfished compared to the base model",
+alt_caption = "Figure showing five retrospective runs with similar estimates for fraction of unfished compared to the base model.",
 label = 'retro_relbio')
 ```
 
-![Likelihood profile showing support from various data sources for different values of ln(R~0~), the natural logarithm of unfished recruitment, relative to the base model. Values associated with likelihoods that fall below the red dashed line are within the 95% chi-squared confidence interval. \label{fig:r0-profile}](../../models/7_3_5_reweight_phases_profile_SR_LN(R0)_prior_like_0/piner_panel_SR_LN(R0).png){width="100%" height="100%" alt="Four-panel figure showing influence of different likelihood components and different fleets within age, length, and survey likelihood components on profile of unfished recruitment"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../../models/7_3_5_reweight_phases_profile_SR_LN(R0)_prior_like_0/piner_panel_SR_LN(R0).png",
+  caption = "Likelihood profile showing support from various data sources for different values of ln(R$_{0}$), the natural logarithm of unfished recruitment, relative to the base model. Values associated with likelihoods that fall below the red dashed line are within the 95 percent chi-squared confidence interval",
+  alt_caption = "Four-panel figure showing influence of different likelihood components and different fleets within age, length, and survey likelihood components on profile of unfished recruitment.",
+  label = "fig:r0-profile"
+)
+```
 
-![Likelihood profile of ln(R~0~), and impact of changing ln(R~0~) values from the base model (blue dot) on depletion (top right), unfished spawning output (lower left), and terminal year spawning output (lower right). \label{fig:r0-profile2}](../../models/7_3_5_reweight_phases_profile_SR_LN(R0)_prior_like_0/parameter_panel_SR_LN(R0).png){width="100%" height="100%" alt="Four-panel figure showing how minimum negative log likelihood, depletion, and spawning output vary with different unfished recruitment parameters"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../../models/7_3_5_reweight_phases_profile_SR_LN(R0)_prior_like_0/parameter_panel_SR_LN(R0).png",
+  caption = "Likelihood profile of ln(R$_{0}$), and impact of changing ln(R$_{0}$) values from the base model (blue dot) on depletion (top right), unfished spawning output (lower left), and terminal year spawning output (lower right)",
+  alt_caption = "Four-panel figure showing how minimum negative log likelihood, depletion, and spawning output vary with different unfished recruitment parameters.",
+  label = "fig:r0-profile2"
+)
+```
 
-![Likelihood profile showing support from various data sources for different values of steepness, relative to the base model. Change in log-likelihood is relative to the base model. Values associated with likelihoods that fall below the red dashed line are within the 95% chi-squared confidence interval. \label{fig:h-profile}](../../models/7_3_5_reweight_profile_SR_BH_steep_prior_like_1/piner_panel_SR_BH_steep.png){width="100%" height="100%" alt="Four-panel figure showing influence of different likelihood components and different fleets within age, length, and survey likelihood components on profile of stock-recruit steepness"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../../models/7_3_5_reweight_profile_SR_BH_steep_prior_like_1/piner_panel_SR_BH_steep.png",
+  caption = "Likelihood profile showing support from various data sources for different values of steepness, relative to the base model. Change in log-likelihood is relative to the base model. Values associated with likelihoods that fall below the red dashed line are within the 95 percent chi-squared confidence interval",
+  alt_caption = "Four-panel figure showing influence of different likelihood components and different fleets within age, length, and survey likelihood components on profile of stock-recruit steepness.",
+  label = "fig:h-profile"
+)
+```
 
-![Likelihood profile of steepness, and impact of changing steepness values from the base model (blue dot) on depletion (top right), unfished spawning output (lower left), and terminal year spawning output (lower right). \label{fig:h-profile2}](../../models/7_3_5_reweight_profile_SR_BH_steep_prior_like_1/parameter_panel_SR_BH_steep.png){width="100%" height="100%" alt="Four-panel figure showing how minimum negative log likelihood, depletion, and spawning output vary with different steepness parameters"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../../models/7_3_5_reweight_profile_SR_BH_steep_prior_like_1/parameter_panel_SR_BH_steep.png",
+  caption = "Likelihood profile of steepness, and impact of changing steepness values from the base model (blue dot) on depletion (top right), unfished spawning output (lower left), and terminal year spawning output (lower right)",
+  alt_caption = "Four-panel figure showing how minimum negative log likelihood, depletion, and spawning output vary with different steepness parameters.",
+  label = "fig:h-profile2"
+)
+```
 
-![Likelihood profile showing support from various data sources for different values of female natural mortality. Change in log-likelihood is relative to the base model. Values associated the likelihoods that fall below the red dashed line are within the 95% chi-squared confidence interval. \label{fig:female-m-profile}](../../models/7_3_5_reweight_profile_NatM_uniform_Fem_GP_1_prior_like_1/piner_panel_NatM_uniform_Fem_GP_1.png){width="100%" height="100%" alt="Four-panel figure showing influence of different likelihood components and different fleets within age, length, and survey likelihood components on profile of female natural mortality"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../../models/7_3_5_reweight_profile_NatM_uniform_Fem_GP_1_prior_like_1/piner_panel_NatM_uniform_Fem_GP_1.png",
+  caption = "Likelihood profile showing support from various data sources for different values of female natural mortality. Change in log-likelihood is relative to the base model. Values associated the likelihoods that fall below the red dashed line are within the 95 percent chi-squared confidence interval",
+  alt_caption = "Four-panel figure showing influence of different likelihood components and different fleets within age, length, and survey likelihood components on profile of female natural mortality.",
+  label = "fig:female-m-profile"
+)
+```
 
-![Likelihood profile of female natural mortality, and impact of changing female natural mortality values from the base model (blue dot) on depletion (top right), unfished spawning output (lower left), and terminal year spawning output (lower right). \label{fig:female-m-profile2}](../../models/7_3_5_reweight_profile_NatM_uniform_Fem_GP_1_prior_like_1/parameter_panel_NatM_uniform_Fem_GP_1.png){width="100%" height="100%" alt="Four-panel figure showing how minimum negative log likelihood, depletion, and spawning output vary with different female natural mortality parameters"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../../models/7_3_5_reweight_profile_NatM_uniform_Fem_GP_1_prior_like_1/parameter_panel_NatM_uniform_Fem_GP_1.png",
+  caption = "Likelihood profile of female natural mortality, and impact of changing female natural mortality values from the base model (blue dot) on depletion (top right), unfished spawning output (lower left), and terminal year spawning output (lower right)",
+  alt_caption = "Four-panel figure showing how minimum negative log likelihood, depletion, and spawning output vary with different female natural mortality parameters.",
+  label = "fig:female-m-profile2"
+)
+```
 
-![Likelihood profile showing support from various data sources for different values of male natural mortality. Change in log-likelihood is relative to the base model. Values associated the likelihoods that fall below the red dashed line are within the 95% chi-squared confidence interval. \label{fig:male-m-profile}](../../models/7_3_5_reweight_profile_NatM_uniform_Mal_GP_1_prior_like_1/piner_panel_NatM_uniform_Mal_GP_1.png){width="100%" height="100%" alt="Four-panel figure showing influence of different likelihood components and different fleets within age, length, and survey likelihood components on profile of male natural mortality"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../../models/7_3_5_reweight_profile_NatM_uniform_Mal_GP_1_prior_like_1/piner_panel_NatM_uniform_Mal_GP_1.png",
+  caption = "Likelihood profile showing support from various data sources for different values of male natural mortality. Change in log-likelihood is relative to the base model. Values associated the likelihoods that fall below the red dashed line are within the 95 percent chi-squared confidence interval",
+  alt_caption = "Four-panel figure showing influence of different likelihood components and different fleets within age, length, and survey likelihood components on profile of male natural mortality.",
+  label = "fig:male-m-profile"
+)
+```
 
-![Likelihood profile of male natural mortality, and impact of changing male natural mortality values from the base model (blue dot) on depletion (top right), unfished spawning output (lower left), and terminal year spawning output (lower right). \label{fig:male-m-profile2}](../../models/7_3_5_reweight_profile_NatM_uniform_Mal_GP_1_prior_like_1/parameter_panel_NatM_uniform_Mal_GP_1.png){width="100%" height="100%" alt="Four-panel figure showing how minimum negative log likelihood, depletion, and spawning output vary with different male natural mortality parameters"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../../models/7_3_5_reweight_profile_NatM_uniform_Mal_GP_1_prior_like_1/parameter_panel_NatM_uniform_Mal_GP_1.png",
+  caption = "Likelihood profile of male natural mortality, and impact of changing male natural mortality values from the base model (blue dot) on depletion (top right), unfished spawning output (lower left), and terminal year spawning output (lower right)",
+  alt_caption = "Four-panel figure showing how minimum negative log likelihood, depletion, and spawning output vary with different male natural mortality parameters.",
+  label = "fig:male-m-profile2"
+)
+```
 
-![Summary biomass (1000s of mt) and age-0 recruitment (millions of fish) of current and past full and update assessments. Summary biomass shows age 5+ canary rockfish with the exception of the 2002 update, which provided summary biomass for age 3+ canary rockfish. \label{fig:hist_compare}](../figures/historical_assessment_smry_biomss.png){width="100%," alt="Figure showing biomass trajectories showing a decline to 2000 followed by an increase until the end year of the assessment"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/historical_assessment_smry_biomss.png",
+  caption = "Summary biomass (1000s of mt) and age-0 recruitment (millions of fish) of current and past full and update assessments. Summary biomass shows age 5+ canary rockfish with the exception of the 2002 update, which provided summary biomass for age 3+ canary rockfish",
+  alt_caption = "Figure showing biomass trajectories showing a decline to 2000 followed by an increase until the end year of the assessment.",
+  label = "fig:hist_compare"
+)
+```
 
-![Comparison of recruitment deviations estimated in DFO (2022) and this model. Deviations are detrended using standard linear regression to account for opposite long-term recruitment trends in the two models. Dashed line is the 1:1 line. Points that fall on this line have perfect correspondence between the two models. \label{fig:canada-rec}](../figures/canada_rec.png){width="100%" height="100%" alt="Scatter plot showing mild correspondence between U.S. and Canada detrended recruitment deviations."}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/canada_rec.png",
+  caption = "Comparison of recruitment deviations estimated in DFO (2022) and this model. Deviations are detrended using standard linear regression to account for opposite long-term recruitment trends in the two models. Dashed line is the 1:1 line. Points that fall on this line have perfect correspondence between the two models",
+  alt_caption = "Scatter plot showing mild correspondence between U.S. and Canada detrended recruitment deviations.",
+  label = "fig:canada-rec"
+)
+```
 
 ## Management
 
-![Estimated yield curve with various reference point proxies. \label{fig:yield}](../figures/plots/yield2_yield_curve_with_refpoints.png){width="100%," height="100%," alt="Yield curve maximized around 0.25 of unfished at yield of about 1200 metric tons"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/plots/yield2_yield_curve_with_refpoints.png",
+  caption = "Estimated yield curve with various reference point proxies",
+  alt_caption = "Yield curve maximized around 0.25 of unfished at yield of about 1200 metric tons.",
+  label = "fig:yield"
+)
+```
 
-![Comparison of spawning output relative to unfished for projections with P*=0.45 under average recruitment assumptions (blue line) and when applying the base projected catch values to a model assuming low recruitment (average recruitment from 2014-2019; red line). Blue band represents 95% confidence interval from the base model. Shaded block indicates the projection period (2023-2034). \label{fig:project-lowrec}](../figures/compare_lowrecruit_projection_Bratio.png){width="100%," height="100%," alt="Figure showing a slight decrease in spawning output for projections under lower recruitment conditions using average recruitment from 2014 to 2019 compared to base conditions using average recruitment over all years"}
+```{r, results = "asis"}
+sa4ss::add_figure(
+  filein = "../figures/compare_lowrecruit_projection_Bratio.png",
+  caption = "Comparison of spawning output relative to unfished for projections with P*=0.45 under average recruitment assumptions (blue line) and when applying the base projected catch values to a model assuming low recruitment (average recruitment from 2014-2019; red line). Blue band represents 95 percent confidence interval from the base model. Shaded block indicates the projection period (2023-2034)",
+  alt_caption = "Figure showing a slight decrease in spawning output for projections under lower recruitment conditions using average recruitment from 2014 to 2019 compared to base conditions using average recruitment over all years.",
+  label = "fig:project-lowrec"
+)
+```


### PR DESCRIPTION
Used regex to change all html inclusion of figures to use `sa4ss::add_figure()`. Also adds full stops to the end of alternative text, changes all percent signs to be the word percent, and uses LaTeX math mode for subscripts rather than using ~.

This file was not checked for compiling.